### PR TITLE
Fix argument names on create_transfer method

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 To execute to ruby specs, run:
 
 ```
-$ WT_API_KEY=your-api-key-here bundle exec rspec
+$ bundle exec rspec
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Or install it yourself as:
 
 You'll need to retrieve an API key from [our developer portal](https://developers.wetransfer.com).
 
-Be sure to not commit this key to Github! If you do though, no worries, you can always revoke & create a new key from within the portal. You will most likely want to pass this to the client using an environment variable.
+Be sure to not commit this key to Github! If you do though, no worries, you can always revoke & create a new key from within the portal.
+
+For configuring and storing secrets - like this API key - there are a variety of solutions. The smoothest here is creating a .env file:
 
 Now that you've got a wonderful WeTransfer API key, create a .env file in your project folder:
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,19 @@ Or install it yourself as:
 
 You'll need to retrieve an API key from [our developer portal](https://developers.wetransfer.com).
 
-Be sure to not commit this key to Github! If you do though, no worries, you can always revoke & create a new key from within the portal. You will most likely want to pass this to the client setter using an environment variable.
+Be sure to not commit this key to Github! If you do though, no worries, you can always revoke & create a new key from within the portal. You will most likely want to pass this to the client using an environment variable.
 
-Now that you've got a wonderful WeTransfer API key, you can create a Client object like so:
+Now that you've got a wonderful WeTransfer API key, create a .env file in your project folder:
+
+    $ touch .env
+
+Check your `.gitignore` file and make sure it has `.env` listed!
+
+Now, open the file in your text editor and add this line:
+
+`WT_API_KEY=<your api key>` (without the <> brackets!)
+
+Great! Now you can go to your project file and create the client:
 
 ```ruby
 # In your project file:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ require 'we_transfer_client'
 Now that you've got the client set up you can use  `create_transfer` to, well, create a transfer!
 
 ```ruby
-transfer = @client.create_transfer(title: "My wonderful transfer", message: "I'm so excited to share this") do |upload|
+transfer = @client.create_transfer(name: "My wonderful transfer", description: "I'm so excited to share this") do |upload|
   upload.add_file_at(path: '/path/to/local/file.jpg')
   upload.add_file_at(path: '/path/to/another/local/file.jpg')
   upload.add_file(name: 'README.txt', io: StringIO.new("This is the contents of the file"))
@@ -75,6 +75,12 @@ $ bundle install
 ```
 
 To install this gem onto your local machine, run `bundle exec rake install`.
+
+To execute to ruby specs, run:
+
+```
+$ WT_API_KEY=your-api-key-here bundle exec rspec
+```
 
 ## Contributing
 

--- a/examples/create_transfer.rb
+++ b/examples/create_transfer.rb
@@ -3,7 +3,7 @@ require 'dotenv'
 Dotenv.load
 
 client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY')) # , logger: Logger.new($stderr))
-transfer = client.create_transfer(title: 'My amazing transfer', message: 'Hi there!') do |builder|
+transfer = client.create_transfer(name: 'My amazing transfer', description: 'Hi there!') do |builder|
   builder.add_file(name: File.basename(__FILE__), io: File.open(__FILE__, 'rb'))
   builder.add_file(name: 'amazing.txt', io: StringIO.new('This is unbelievable'))
   builder.add_file(name: 'huge.bin', io: File.open('/path/to/local/file.jpg', 'rb'))

--- a/lib/we_transfer_client.rb
+++ b/lib/we_transfer_client.rb
@@ -83,11 +83,11 @@ class WeTransferClient
     @logger = logger
   end
 
-  def create_transfer(title:, message:)
+  def create_transfer(name:, description:)
     builder = TransferBuilder.new
     yield(builder)
     raise 'The transfer you have tried to create contains no items' if builder.items.empty?
-    future_transfer = FutureTransfer.new(name: title, description: message, items: builder.items)
+    future_transfer = FutureTransfer.new(name: name, description: description, items: builder.items)
     create_and_upload(future_transfer)
   end
 

--- a/lib/we_transfer_client/version.rb
+++ b/lib/we_transfer_client/version.rb
@@ -1,3 +1,3 @@
 class WeTransferClient
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -26,7 +26,7 @@ describe WeTransferClient do
 
   it 'is able to create a transfer start to finish, both with small and large files' do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
-    transfer = client.create_transfer(title: 'My amazing board', message: 'Hi there!') do |builder|
+    transfer = client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
       # Upload ourselves
       add_result = builder.add_file(name: File.basename(__FILE__), io: File.open(__FILE__, 'rb'))
       expect(add_result).to eq(true)
@@ -64,7 +64,7 @@ describe WeTransferClient do
   it 'refuses to create a transfer with no items' do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
     expect {
-      client.create_transfer(title: 'My amazing board', message: 'Hi there!') do |builder|
+      client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
         # ...do nothing
       end
     }.to raise_error(/no items/)
@@ -79,7 +79,7 @@ describe WeTransferClient do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
     expect(client).not_to receive(:faraday) # Since we will not be doing any requests - we fail earlier
     expect {
-      client.create_transfer(title: 'My amazing board', message: 'Hi there!') do |builder|
+      client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
         builder.add_file(name: 'broken', io: broken)
       end
     }.to raise_error(/failed somehow/)
@@ -90,7 +90,7 @@ describe WeTransferClient do
 
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
     expect {
-      client.create_transfer(title: 'My amazing board', message: 'Hi there!') do |builder|
+      client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
         builder.add_file(name: 'broken', io: broken)
       end
     }.to raise_error(/has a size of 0/)

--- a/wetransfer.gemspec
+++ b/wetransfer.gemspec
@@ -27,6 +27,13 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.post_install_message = %q{
+    Warning: We have changed the syntax for the create_transfer method.
+
+    create_transfer(title:, message:) is now create_transfer(name:, description:)
+
+    Please update your usage accordingly. Thank you and our apologies for the disruption.
+  }
 
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'ks', '~> 0.0.1'

--- a/wetransfer.gemspec
+++ b/wetransfer.gemspec
@@ -29,9 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.post_install_message = %q{
     Warning: We have changed the syntax for the create_transfer method.
-
     create_transfer(title:, message:) is now create_transfer(name:, description:)
-
     Please update your usage accordingly. Thank you and our apologies for the disruption.
   }
 


### PR DESCRIPTION
## Proposed changes

The named arguments exposed on `create_transfer` method are not aligned with the API definition, nor with the rest of the SDKs.

## Types of changes

- [x] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wetransfer_ruby_sdk/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules