### PR TITLE
Add support for blank transfers to the SDK Fix #14

### DIFF
--- a/lib/we_transfer_client.rb
+++ b/lib/we_transfer_client.rb
@@ -86,7 +86,6 @@ class WeTransferClient
   def create_transfer(name:, description:)
     builder = TransferBuilder.new
     yield(builder)
-    raise 'The transfer you have tried to create contains no items' if builder.items.empty?
     future_transfer = FutureTransfer.new(name: name, description: description, items: builder.items)
     create_and_upload(future_transfer)
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -61,7 +61,7 @@ describe WeTransferClient do
     expect(response['location']).to start_with('https://wetransfer')
   end
 
-  it 'refuses to create a transfer with no items' do
+  it 'is able to create a transfer with no items' do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
     response = client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -63,13 +63,10 @@ describe WeTransferClient do
 
   it 'refuses to create a transfer with no items' do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
-      response = client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
-        # ...do nothing
-      end
-      expect(response[:size]).to eq(0)
-      # expect(response[:total_items]).to eq(0)
-      expect(response[:items]).to eq([])
-
+    response = client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
+    end
+    expect(response[:size]).to eq(0)
+    expect(response[:items]).to eq([])
   end
 
   it 'refuses to create a transfer when reading an IO raises an error' do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -61,13 +61,15 @@ describe WeTransferClient do
     expect(response['location']).to start_with('https://wetransfer')
   end
 
-  it 'refuses to create a transfer with no items' do
+  it 'refuses to create a transfer with no items', :focus => true do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
-    expect {
-      client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
+      response = client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
         # ...do nothing
       end
-    }.to raise_error(/no items/)
+      expect(response[:size]).to eq(0)
+      # expect(response[:total_items]).to eq(0)
+      expect(response[:items]).to eq([])
+
   end
 
   it 'refuses to create a transfer when reading an IO raises an error' do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -61,7 +61,7 @@ describe WeTransferClient do
     expect(response['location']).to start_with('https://wetransfer')
   end
 
-  it 'refuses to create a transfer with no items', :focus => true do
+  it 'refuses to create a transfer with no items' do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
       response = client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
         # ...do nothing


### PR DESCRIPTION
## Proposed changes

Fix #14 

## Types of changes

What types of changes does your code introduce to wetransfer_ruby_sdk?
_Put an `x` in the boxes that apply_

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wetransfer_ruby_sdk/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [x] Any dependent changes have been merged and published in downstream modules
