### PR TITLE
Add spec_helper

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,9 +1,4 @@
-require 'tempfile'
-require 'bundler'
-Bundler.setup
-
-require 'dotenv'
-Dotenv.load
+require 'spec_helper'
 
 require_relative '../lib/we_transfer_client.rb'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,19 @@
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
+require 'we_transfer_client'
+require 'pry'
+require 'rspec'
+require 'bundler'
+Bundler.setup
+require 'tempfile'
+require 'dotenv'
+Dotenv.load
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
## Proposed changes

We removed the spec_helper, but we'll probably need it soon (if not now for the envvar loader) so let's put it back. 

## Types of changes

What types of changes does your code introduce to wetransfer_ruby_sdk?
_Put an `x` in the boxes that apply_

- [ ] Docs (missing or updated docs)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wetransfer_ruby_sdk/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...