### PR TITLE
Add async option for uploads

### DIFF
--- a/lib/we_transfer_client.rb
+++ b/lib/we_transfer_client.rb
@@ -84,10 +84,10 @@ class WeTransferClient
     @api_key = api_key.to_str
     @bearer_token = nil
     @logger = logger
-    if async
-      @pool = Concurrent::FixedThreadPool.new(POOL_SIZE)
+    @pool = if async
+      Concurrent::FixedThreadPool.new(POOL_SIZE)
     else
-      @pool = nil
+      nil
     end
   end
 
@@ -153,7 +153,7 @@ class WeTransferClient
         part_io = StringIO.new(io.read(MAGIC_PART_SIZE))
         part_io.rewind
         lambda do |part_io, item_id, part_n_one_based, multipart_id|
-          Concurrent::Promise.execute(:executor => @pool) do
+          Concurrent::Promise.execute(executor: @pool) do
             get_upload_url(item_id, part_n_one_based, multipart_id)
           end.then do |upload_url|
             upload_chunk(upload_url, part_io)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -67,6 +67,43 @@ describe WeTransferClient do
     expect(response['location']).to start_with('https://wetransfer')
   end
 
+  it 'is able to create a transfer start to finish, both with small and large files with async enabled' do
+    client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger, async: true)
+    transfer = client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
+      # Upload ourselves
+      add_result = builder.add_file(name: File.basename(__FILE__), io: File.open(__FILE__, 'rb'))
+      expect(add_result).to eq(true)
+
+      # Upload ourselves again, but using add_file_at
+      add_result = builder.add_file_at(path: __FILE__) # Upload ourselves again, but this time via path
+      expect(add_result).to eq(true)
+
+      # Upload the large file
+      add_result = builder.add_file(name: 'large.bin', io: very_large_file)
+      expect(add_result).to eq(true)
+
+      expect(add_result).to eq(true)
+    end
+
+    expect(transfer).to be_kind_of(WeTransferClient::RemoteTransfer)
+    expect(transfer.id).to be_kind_of(String)
+
+    # expect(transfer.version_identifier).to be_kind_of(String)
+    expect(transfer.state).to be_kind_of(String)
+    expect(transfer.name).to eq('My amazing board')
+    expect(transfer.description).to eq('Hi there!')
+    expect(transfer.items).to be_kind_of(Array)
+    expect(transfer.items.length).to eq(3)
+
+    item = transfer.items.first
+    expect(item).to be_kind_of(WeTransferClient::RemoteItem)
+
+    expect(transfer.shortened_url).to be_kind_of(String)
+    response = Faraday.get(transfer.shortened_url)
+    expect(response.status).to eq(302)
+    expect(response['location']).to start_with('https://wetransfer')
+  end
+
   it 'can transfer files async faster' do
     syncflow_time =  timeit do
       client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -100,7 +100,7 @@ describe WeTransferClient do
   end
 
   it 'can transfer files async faster' do
-    syncflow_time =  timeit do
+    syncflow_time = timeit do
       client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
       client.create_transfer(name: 'My amazing board', description: 'Hi there!') do |builder|
         # Upload the large file

--- a/wetransfer.gemspec
+++ b/wetransfer.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'ks', '~> 0.0.1'
+  spec.add_dependency 'concurrent-ruby', '~> 1.0.5'
 
   spec.add_development_dependency 'dotenv', '~> 2.2'
   spec.add_development_dependency 'bundler', '~> 1.16'


### PR DESCRIPTION
## Proposed changes

It adds an option for performing async chunks upload that will increase upload speed

## Types of changes

What types of changes does your code introduce to wetransfer_ruby_sdk?
_Put an `x` in the boxes that apply_

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wetransfer_ruby_sdk/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

In the tests there where a 7 seconds improvement, not sure if it makes a difference since it loads the server 5 times more for each upload