### PR TITLE
Bugfix, webcontent url

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ transfer = @client.create_transfer(name: "My wonderful transfer", description: "
   upload.add_file_at(path: '/path/to/local/file.jpg')
   upload.add_file_at(path: '/path/to/another/local/file.jpg')
   upload.add_file(name: 'README.txt', io: StringIO.new("This is the contents of the file"))
-  upload.add_web_content(path: "https://www.the.url.you.want.to.share.com"))
+  upload.add_web_content(url: "https://www.the.url.you.want.to.share.com"))
 end
 
 transfer.shortened_url => "https://we.tl/SSBsb3ZlIHJ1Ynk="

--- a/lib/we_transfer_client/transfer_builder.rb
+++ b/lib/we_transfer_client/transfer_builder.rb
@@ -16,10 +16,8 @@ class TransferBuilder
     add_file(name: File.basename(path), io: File.open(path, 'rb'))
   end
 
-  def add_web_content(path:)
-    url = open(path, allow_redirections: :safe).base_uri.to_s
-    url_title = url.split('/').last
-    @items << FutureWebItem.new(url: url, title: url_title)
+  def add_web_content(url:)
+    @items << FutureWebItem.new(url: url, title: url)
     true
   end
 

--- a/lib/we_transfer_client/version.rb
+++ b/lib/we_transfer_client/version.rb
@@ -1,3 +1,3 @@
 class WeTransferClient
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -97,7 +97,7 @@ describe WeTransferClient do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
     transfer = client.create_transfer(name: 'My collection of web content', description: 'link collection') do |builder|
       10.times do
-        builder.add_web_content(path: 'https://www.wetransfer.com')
+        builder.add_web_content(url: 'https://www.wetransfer.com')
       end
     end
     expect(transfer).to be_kind_of(RemoteTransfer)
@@ -135,7 +135,7 @@ describe WeTransferClient do
       expect(add_result).to eq(true)
 
       # add url to transfer
-      add_result = builder.add_web_content(path: 'http://www.wetransfer.com')
+      add_result = builder.add_web_content(url: 'http://www.wetransfer.com')
       expect(add_result).to eq(true)
     end
 

--- a/spec/we_transfer_client/transfer_builder_spec.rb
+++ b/spec/we_transfer_client/transfer_builder_spec.rb
@@ -29,7 +29,7 @@ describe TransferBuilder do
 
   it 'should add a url' do
     transfer_builder = described_class.new
-    transfer_builder.add_web_content(path: 'https://www.wetransfer.com')
+    transfer_builder.add_web_content(url: 'https://www.wetransfer.com')
     expect(transfer_builder.items.count).to eq(1)
 
     item = transfer_builder.items.first

--- a/spec/we_transfer_client/transfer_builder_spec.rb
+++ b/spec/we_transfer_client/transfer_builder_spec.rb
@@ -29,12 +29,12 @@ describe TransferBuilder do
 
   it 'should add a url' do
     transfer_builder = described_class.new
-    transfer_builder.add_web_content(url: 'https://www.wetransfer.com')
+    transfer_builder.add_web_content(url: 'https://www.wetransfer.com/')
     expect(transfer_builder.items.count).to eq(1)
 
     item = transfer_builder.items.first
-    expect(item.url).to eq('https://wetransfer.com/')
-    expect(item.title).to eq('wetransfer.com')
+    expect(item.url).to eq('https://www.wetransfer.com/')
+    expect(item.title).to eq('https://www.wetransfer.com/')
     expect(item.local_identifier).to be_kind_of(String)
   end
 end


### PR DESCRIPTION
## Proposed changes

instead of opening the url, send it to your transfer and use it as the title. It seems to be unnecessary to open the url before passing.  

## Types of changes

What types of changes does your code introduce to wetransfer_ruby_sdk?
_Put an `x` in the boxes that apply_

- [ ] Docs (missing or updated docs)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wetransfer_ruby_sdk/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...