### PR TITLE
Moved gem from dev dep to actual dependency

### DIFF
--- a/lib/we_transfer_client/version.rb
+++ b/lib/we_transfer_client/version.rb
@@ -1,3 +1,3 @@
 class WeTransferClient
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end

--- a/wetransfer.gemspec
+++ b/wetransfer.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 0.12'
   spec.add_dependency 'ks', '~> 0.0.1'
+  spec.add_dependency 'open_uri_redirections'
 
   spec.add_development_dependency 'dotenv', '~> 2.2'
   spec.add_development_dependency 'bundler', '~> 1.16'
@@ -38,5 +39,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.15'
   spec.add_development_dependency 'wetransfer_style', '0.5.0'
-  spec.add_development_dependency 'open_uri_redirections'
 end


### PR DESCRIPTION
## Proposed changes

This will fix the error where the require wouldn't work because the gem was a development dependency

## Types of changes

What types of changes does your code introduce to wetransfer_ruby_sdk?
_Put an `x` in the boxes that apply_

- [ ] Docs (missing or updated docs)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wetransfer_ruby_sdk/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...