### PR TITLE
Add support for web-based clients 

### DIFF
--- a/lib/we_transfer_client.rb
+++ b/lib/we_transfer_client.rb
@@ -61,7 +61,7 @@ class WeTransferClient
       auth_headers
     )
     ensure_ok_status!(response)
-    response = JSON.parse(response.body, symbolize_names: true)
+    JSON.parse(response.body, symbolize_names: true)
   end
 
   def complete_item!(item_id:)

--- a/lib/we_transfer_client.rb
+++ b/lib/we_transfer_client.rb
@@ -120,6 +120,22 @@ class WeTransferClient
     ensure_ok_status!(complete_response)
   end
 
+  def create_items_structs(items)
+    items.map do |item|
+      case item.keys
+      when [:name, :io]
+        FutureFileItem.new(name: item[:name], io: item[:io])
+      when [:path]
+        FutureFileItem.new(name: File.basename(item[:path]), io: File.open(item[:path], 'rb'))
+      when [:url, :title]
+        FutureWebItem.new(url: item[:url], title: item[:title])
+      else
+        @logger.error { item }
+        raise Error, "Item uses wrong keys: #{item.keys}, use 'name', 'io', 'path' or 'url' instead"
+      end
+    end
+  end
+
   def hash_to_struct(hash, struct_class)
     members = struct_class.members
     struct_attrs = Hash[members.zip(hash.values_at(*members))]

--- a/lib/we_transfer_client.rb
+++ b/lib/we_transfer_client.rb
@@ -3,8 +3,6 @@ require 'logger'
 require 'ks'
 require 'securerandom'
 require 'json'
-require 'open-uri'
-require 'open_uri_redirections'
 
 class WeTransferClient
   require_relative 'we_transfer_client/version'
@@ -51,7 +49,7 @@ class WeTransferClient
     upload_transfer_items(updated_transfer.items, remote_transfer) unless manual_upload
     return_as_struct(remote_transfer)
   rescue LocalJumpError
-    raise Error, 'No items where added to the transfer'
+    raise ArgumentError, 'No items where added to the transfer'
   end
 
   def request_item_upload_url(item:, part_number:)

--- a/lib/we_transfer_client/future_transfer.rb
+++ b/lib/we_transfer_client/future_transfer.rb
@@ -6,4 +6,12 @@ class FutureTransfer < Ks.strict(:name, :description, :items)
       items: items.map(&:to_item_request_params),
     }
   end
+
+  def to_add_items_to_transfer_params
+    {
+      name: name,
+      description: description,
+      items: items.map(&:to_item_request_params),
+    }
+  end
 end

--- a/lib/we_transfer_client/remote_item.rb
+++ b/lib/we_transfer_client/remote_item.rb
@@ -1,2 +1,2 @@
-class RemoteItem < Ks.strict(:id, :local_identifier, :content_identifier, :name, :size, :mime_type, :url, :title)
+class RemoteItem < Ks.strict(:id, :local_identifier, :content_identifier, :name, :size, :mime_type, :upload_url, :title, :upload_id, :meta)
 end

--- a/lib/we_transfer_client/version.rb
+++ b/lib/we_transfer_client/version.rb
@@ -1,3 +1,3 @@
 class WeTransferClient
-  VERSION = '0.4.3'
+  VERSION = '0.5.0'
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -152,17 +152,17 @@ describe WeTransferClient do
 
   it 'is able to do create a empty transfer to add items later' do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
-    transfer = client.initialize_transfer(name: 'Board', description: 'Test board for functionality')
+    transfer = client.create_transfer(name: 'Board', description: 'Test board for functionality')
     expect(transfer.size).to eq(0)
     expect(transfer.items).to eq([])
   end
 
   it 'add items to a excisting transfer using a block' do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
-    transfer = client.initialize_transfer(name: 'Board', description: 'Test board for functionality')
+    transfer = client.create_transfer(name: 'Board', description: 'Test board for functionality')
     expect(transfer.items).to eq([])
 
-    updated_transfer = client.add_items_transfer(transfer: transfer) do |item|
+    updated_transfer = client.(transfer: transfer) do |item|
       item.add_file(name: File.basename(__FILE__), io: File.open(__FILE__, 'rb'))
       item.add_file_at(path: __FILE__)
       item.add_file(name: 'large.bin', io: very_large_file)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -189,7 +189,7 @@ describe WeTransferClient do
 
     expect {
       client.add_items_to(transfer: transfer)
-    }.to raise_error WeTransferClient::Error, /No items where added to the transfer/
+    }.to raise_error(WeTransferClient::Error, /No items where added to the transfer/)
   end
 
   it 'is should support a manual way for uploading files with a block' do
@@ -217,7 +217,7 @@ describe WeTransferClient do
       expect(upload_response.status).to eq(200)
     end
     complete_response = client.complete_item!(item_id: first_item.id)
-    expect(complete_response[:message]).to match(/ File is marked as complete. /)
+    expect(complete_response[:message]).to match(/File is marked as complete./)
   end
 
   it 'should support a manual way for uploading files without a block' do
@@ -253,7 +253,7 @@ describe WeTransferClient do
         expect(upload_response.status).to eq(200)
       end
       complete_response = client.complete_item!(item_id: item.id)
-      expect(complete_response[:message]).to match(/ File is marked as complete. /)
+      expect(complete_response[:message]).to match(/File is marked as complete./)
     end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -189,7 +189,7 @@ describe WeTransferClient do
 
     expect {
       client.add_items_to(transfer: transfer)
-    }.to raise_error(WeTransferClient::Error, /No items where added to the transfer/)
+    }.to raise_error(WeTransferClient::ArgumentError, /No items where added to the transfer/)
   end
 
   it 'is should support a manual way for uploading files with a block' do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -188,7 +188,7 @@ describe WeTransferClient do
     expect(transfer.items).to eq([])
 
     expect {
-      updated_transfer = client.add_items_to(transfer: transfer)
+      client.add_items_to(transfer: transfer)
     }.to raise_error WeTransferClient::Error, /No items where added to the transfer/
   end
 
@@ -217,8 +217,7 @@ describe WeTransferClient do
       expect(upload_response.status).to eq(200)
     end
     complete_response = client.complete_item!(item_id: first_item.id)
-    binding.pry
-    expect(complete_response[:message]).to match /File is marked as complete./
+    expect(complete_response[:message]).to match(/ File is marked as complete. /)
   end
 
   it 'should support a manual way for uploading files without a block' do
@@ -254,7 +253,7 @@ describe WeTransferClient do
         expect(upload_response.status).to eq(200)
       end
       complete_response = client.complete_item!(item_id: item.id)
-      expect(complete_response[:message]).to match /File is marked as complete./
+      expect(complete_response[:message]).to match(/ File is marked as complete. /)
     end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -152,14 +152,14 @@ describe WeTransferClient do
 
   it 'is able to do create a empty transfer to add items later' do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
-    transfer = client.initialize_transfer(name: 'Async Board', description: 'Test board for async functionality')
+    transfer = client.initialize_transfer(name: 'Board', description: 'Test board for functionality')
     expect(transfer.size).to eq(0)
     expect(transfer.items).to eq([])
   end
 
   it 'should add items to a previous created transfer' do
     client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
-    transfer = client.initialize_transfer(name: 'Async Board', description: 'Test board for async functionality')
+    transfer = client.initialize_transfer(name: 'Board', description: 'Test board for functionality')
     expect(transfer.items.size).to eq(0)
     items = [
       {name: File.basename(__FILE__), io: File.open(__FILE__, 'rb')},
@@ -179,5 +179,16 @@ describe WeTransferClient do
     response = client.initialize_transfer(name: 'My amazing board', description: 'Hi there!')
     expect(response.size).to eq(0)
     expect(response.items).to eq([])
+  end
+
+  it 'should return an error when files have the wrong keys inside hash' do
+      client = WeTransferClient.new(api_key: ENV.fetch('WT_API_KEY'), logger: test_logger)
+      transfer = client.initialize_transfer(name: 'Board', description: 'Test board for functionality')
+      items = [
+        {foo: File.basename(__FILE__), bar: File.open(__FILE__, 'rb')}
+      ]
+    expect{
+      transfer = client.add_items_to_transfer(transfer: transfer, items: items)
+    }.to raise_error(WeTransferClient::Error, "Item uses wrong keys: [:foo, :bar], use 'name', 'io', 'path' or 'url' instead")
   end
 end

--- a/wetransfer.gemspec
+++ b/wetransfer.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 0.12'
   spec.add_dependency 'ks', '~> 0.0.1'
-  spec.add_dependency 'open_uri_redirections'
 
   spec.add_development_dependency 'dotenv', '~> 2.2'
   spec.add_development_dependency 'bundler', '~> 1.16'


### PR DESCRIPTION
## Proposed changes

This Pr add the functionality to create empty transfers, add items to existing transfers, request upload urls for item parts and complete items. 

## Types of changes

What types of changes does your code introduce to wetransfer_ruby_sdk?
_Put an `x` in the boxes that apply_

- [x] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wetransfer_ruby_sdk/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [x] Any dependent changes have been merged and published in downstream modules
