### PR TITLE
Fix bug on remote transfer initializer

### DIFF
--- a/lib/we_transfer_client/remote_transfer.rb
+++ b/lib/we_transfer_client/remote_transfer.rb
@@ -1,7 +1,7 @@
 class RemoteTransfer
   attr_reader :files, :url, :state, :id
 
-  def initialize(id:, state:, url:, message:, files: [])
+  def initialize(id:, state:, url:, message:, files: [], **)
     @id = id
     @state = state
     @message = message

--- a/spec/we_transfer_client/remote_transfer_spec.rb
+++ b/spec/we_transfer_client/remote_transfer_spec.rb
@@ -7,6 +7,7 @@ describe RemoteTransfer do
       state: 'uploading',
       message: 'Test transfer',
       url: nil,
+      success: true,
       files:
         [
           {


### PR DESCRIPTION
## Proposed changes

The API responds with an extra parameter `success: true` to avoid crashing the gem when the API is upgraded the rest of the parameters not used from the API respond are ignored

## Types of changes

What types of changes does your code introduce to wetransfer_ruby_sdk?
_Put an `x` in the boxes that apply_

- [ ] Docs (missing or updated docs)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wetransfer_ruby_sdk/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...