### PR TITLE
Fix: Handle unknown key for remote_board init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ rvm:
 - 2.3
 - 2.4
 - 2.5
+- 2.6
 - jruby-9.0
-before_install: gem install bundler -v 1.16.1
+before_install: echo Y | rvm @global do gem uninstall bundler ; gem install bundler -v 1.16.1
 cache: bundler
 matrix:
   allow_failures:

--- a/lib/we_transfer_client/remote_board.rb
+++ b/lib/we_transfer_client/remote_board.rb
@@ -5,7 +5,7 @@ class RemoteBoard
 
   CHUNK_SIZE = 6 * 1024 * 1024
 
-  def initialize(id:, state:, url:, name:, description: '', items: [])
+  def initialize(id:, state:, url:, name:, description: '', items: [], **)
     @id = id
     @state = state
     @url = url

--- a/lib/we_transfer_client/version.rb
+++ b/lib/we_transfer_client/version.rb
@@ -1,3 +1,3 @@
 module WeTransfer
-  VERSION = '0.9.0.beta2'
+  VERSION = '0.9.0.beta3'
 end

--- a/spec/we_transfer_client/transfers_spec.rb
+++ b/spec/we_transfer_client/transfers_spec.rb
@@ -35,7 +35,7 @@ describe WeTransfer::Client::Transfers do
           builder.add_file(name: 'README.txt', io: StringIO.new("A thing"))
           builder.add_file(name: 'README.txt', io: StringIO.new("another thing"))
         end
-      }.to raise_error ArgumentError, /Duplicate file entry/
+      }.to raise_error WeTransfer::Client::Error
     end
   end
 


### PR DESCRIPTION
## Proposed changes
This Pr solves an issue with creating a remote_board but the response body contains an unknow key "success" , this fix will convert it into a key but doens't do anything with the key

## Types of changes

What types of changes does your code introduce to wetransfer_ruby_sdk?
_Put an `x` in the boxes that apply_

- [ ] Docs (missing or updated docs)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wetransfer_ruby_sdk/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...